### PR TITLE
Checking email uses @u.nus.edu or @comp.nus.edu.sg during registration

### DIFF
--- a/lib/screens/authenticate/register.dart
+++ b/lib/screens/authenticate/register.dart
@@ -90,7 +90,10 @@ class _RegisterState extends State<Register> {
                               ),
                               validator: (val) {
                                 if (val!.isEmpty) {
-                                  return 'Please enter a valid email';
+                                  return 'Please enter an email';
+                                } else if (!val.endsWith('@u.nus.edu') &&
+                                    !val.endsWith('@comp.nus.edu.sg')) {
+                                  return 'Email domain should be @u.nus.edu or @comp.nus.edu.sg';
                                 } else {
                                   return null;
                                 }


### PR DESCRIPTION
Previously, firebase could not send emails to @u.nus.edu email accounts (unknown reason). Currently, it seems to be working so we are implementing this feature to ensure that the users of freshSoC are strictly SoC staff/students which are the intended audience of our application.